### PR TITLE
Allow building with `bytestring-0.11`

### DIFF
--- a/binary-parsers.cabal
+++ b/binary-parsers.cabal
@@ -30,7 +30,7 @@ library
                     ,   Data.Binary.Parser.Numeric
 
     build-depends:      base == 4.*
-                    ,   bytestring == 0.10.*
+                    ,   bytestring >= 0.10 && < 0.12
                     ,   binary == 0.8.*
                     ,   bytestring-lexing == 0.5.*
                     ,   scientific > 0.3


### PR DESCRIPTION
This is needed to allow `binary-parsers` to build with GHC 9.2.